### PR TITLE
Add ability to encode and decode "extended txrefs" which enable referencing a specific UTXO in a transaction

### DIFF
--- a/tests.js
+++ b/tests.js
@@ -7,6 +7,7 @@ let txrefConverter = require('./txrefConverter');
 
 
 describe('Bech32 TX', function () {
+
   describe('encoding', function () {
     it('encodes a tx with block height 0 and pos 0', function (done) {
       let blockHeight = 0;
@@ -115,11 +116,14 @@ describe('Bech32 TX', function () {
   });
 
   describe('decode', function () {
-    it('decodes a tx with block height 0 and pos 0', function (done) {
+    it('decodes tx ref tx1-rqqq-qqqq-qmhu-qk', function (done) {
       let blockHeight = 0;
       let txPos = 0;
-      let result = txrefConverter.txrefEncode(txrefConverter.CHAIN_MAINNET, blockHeight, txPos);
-      expect(result).to.equal('tx1-rqqq-qqqq-qmhu-qk');
+
+      let result = txrefConverter.txrefDecode('tx1-rqqq-qqqq-qmhu-qk');
+      expect(result.blockHeight).to.equal(blockHeight);
+      expect(result.blockIndex).to.equal(txPos);
+      expect(result.chain).to.equal(txrefConverter.CHAIN_MAINNET);
       done();
     });
 
@@ -255,6 +259,191 @@ describe('Bech32 TX', function () {
       done();
     });
     //  txid: f8cdaff3ebd9e862ed5885f8975489090595abe1470397f79780ead1c7528107
+  });
+
+  describe('encoding extended', function () {
+    it('encodes a txref-ext with block height 0, pos 0, utxo index 0', function (done) {
+      let blockHeight = 0;
+      let txPos = 0;
+      let utxoIndex = 0;
+      let result = txrefConverter.txrefextEncode(txrefConverter.CHAIN_MAINNET, blockHeight, txPos, utxoIndex);
+      expect(result).to.equal('tx1-rqqq-qqqq-qqqu-au7hl');
+      done();
+    });
+    
+    it('encodes a txref-ext with block height 0, pos 0, utxo index 100', function (done) {
+      let blockHeight = 0;
+      let txPos = 0;
+      let utxoIndex = 100;
+      let result = txrefConverter.txrefextEncode(txrefConverter.CHAIN_MAINNET, blockHeight, txPos, utxoIndex);
+      expect(result).to.equal('tx1-rqqq-qqqq-yrq9-mqh4w');
+      done();
+    });
+    
+    it('encodes a txref-ext with block height 0, pos 0, utxo index 0x1FFF', function (done) {
+      let blockHeight = 0;
+      let txPos = 0;
+      let utxoIndex = 0x1FFF;
+      let result = txrefConverter.txrefextEncode(txrefConverter.CHAIN_MAINNET, blockHeight, txPos, utxoIndex);
+      expect(result).to.equal('tx1-rqqq-qqqq-ll8t-emcac');
+      done();
+    });
+    
+    it('encodes a txref-ext with block height 0, pos 0x1FFF, utxo index 0', function (done) {
+      let blockHeight = 0;
+      let txPos = 0x1FFF;
+      let utxoIndex = 0;
+      let result = txrefConverter.txrefextEncode(txrefConverter.CHAIN_MAINNET, blockHeight, txPos, utxoIndex);
+      expect(result).to.equal('tx1-rqqq-qull-qqq5-ktx95');
+      done();
+    });
+    
+    it('encodes a txref-ext with block height 0, pos 0x1FFF, utxo index 100', function (done) {
+      let blockHeight = 0;
+      let txPos = 0x1FFF;
+      let utxoIndex = 100;
+      let result = txrefConverter.txrefextEncode(txrefConverter.CHAIN_MAINNET, blockHeight, txPos, utxoIndex);
+      expect(result).to.equal('tx1-rqqq-qull-yrqd-sh089');
+      done();
+    });
+    
+    it('encodes a txref-ext with block height 0x1FFFFF, pos 0, utxo index 0', function (done) {
+      let blockHeight = 0x1FFFFF;
+      let txPos = 0;
+      let utxoIndex = 0;
+      let result = txrefConverter.txrefextEncode(txrefConverter.CHAIN_MAINNET, blockHeight, txPos, utxoIndex);
+      expect(result).to.equal('tx1-r7ll-lrqq-qqqm-m5vjv');
+      done();
+    });
+    
+    it('encodes a txref-ext with block height 0x1FFFFF, pos 0x1FFF, utxo index 0', function (done) {
+      let blockHeight = 0x1FFFFF;
+      let txPos = 0x1FFF;
+      let utxoIndex = 0;
+      let result = txrefConverter.txrefextEncode(txrefConverter.CHAIN_MAINNET, blockHeight, txPos, utxoIndex);
+      expect(result).to.equal('tx1-r7ll-llll-qqqn-sr5q8');
+      done();
+    });
+    
+    it('encodes a txref-ext with block height 0x1FFFFF, pos 0x1FFF, utxo index 100', function (done) {
+      let blockHeight = 0x1FFFFF;
+      let txPos = 0x1FFF;
+      let utxoIndex = 100;
+      let result = txrefConverter.txrefextEncode(txrefConverter.CHAIN_MAINNET, blockHeight, txPos, utxoIndex);
+      expect(result).to.equal('tx1-r7ll-llll-yrq2-klazk');
+      done();
+    });
+  });
+
+  describe('decode extended', function () {
+    it('decodes txef-ext tx1-rqqq-qqqq-qqqu-au7hl', function (done) {
+      let blockHeight = 0;
+      let txPos = 0;
+      let utxoIndex = 0;
+
+      let result = txrefConverter.txrefextDecode('tx1-rqqq-qqqq-qqqu-au7hl');
+      expect(result.blockHeight).to.equal(blockHeight);
+      expect(result.blockIndex).to.equal(txPos);
+      expect(result.utxoIndex).to.equal(utxoIndex);
+      expect(result.chain).to.equal(txrefConverter.CHAIN_MAINNET);
+      done();
+    });
+
+    it('decodes txef-ext tx1-rqqq-qqqq-yrq9-mqh4w', function (done) {
+      let blockHeight = 0;
+      let txPos = 0;
+      let utxoIndex = 100;
+
+      let result = txrefConverter.txrefextDecode('tx1-rqqq-qqqq-yrq9-mqh4w');
+      expect(result.blockHeight).to.equal(blockHeight);
+      expect(result.blockIndex).to.equal(txPos);
+      expect(result.utxoIndex).to.equal(utxoIndex);
+      expect(result.chain).to.equal(txrefConverter.CHAIN_MAINNET);
+      done();
+    });
+
+    it('decodes txef-ext tx1-rqqq-qqqq-ll8t-emcac', function (done) {
+      let blockHeight = 0;
+      let txPos = 0;
+      let utxoIndex = 0x1FFF;
+
+      let result = txrefConverter.txrefextDecode('tx1-rqqq-qqqq-ll8t-emcac');
+      expect(result.blockHeight).to.equal(blockHeight);
+      expect(result.blockIndex).to.equal(txPos);
+      expect(result.utxoIndex).to.equal(utxoIndex);
+      expect(result.chain).to.equal(txrefConverter.CHAIN_MAINNET);
+      done();
+    });
+
+    it('decodes txef-ext tx1-rqqq-qull-qqq5-ktx95', function (done) {
+      let blockHeight = 0;
+      let txPos = 0x1FFF;
+      let utxoIndex = 0;
+
+      let result =
+      txrefConverter.txrefextDecode('tx1-rqqq-qull-qqq5-ktx95');
+      expect(result.blockHeight).to.equal(blockHeight);
+      expect(result.blockIndex).to.equal(txPos);
+      expect(result.utxoIndex).to.equal(utxoIndex);
+      expect(result.chain).to.equal(txrefConverter.CHAIN_MAINNET);
+      done();
+    });
+
+    it('decodes txef-ext tx1-rqqq-qull-yrqd-sh089', function (done) {
+      let blockHeight = 0;
+      let txPos = 0x1FFF;
+      let utxoIndex = 100;
+
+      let result =
+      txrefConverter.txrefextDecode('tx1-rqqq-qull-yrqd-sh089');
+      expect(result.blockHeight).to.equal(blockHeight);
+      expect(result.blockIndex).to.equal(txPos);
+      expect(result.utxoIndex).to.equal(utxoIndex);
+      expect(result.chain).to.equal(txrefConverter.CHAIN_MAINNET);
+      done();
+    });
+  
+    it('decodes txef-ext tx1-r7ll-lrqq-qqqm-m5vjv', function (done) {
+      let blockHeight = 0x1FFFFF;
+      let txPos = 0;
+      let utxoIndex = 0;
+
+      let result =
+      txrefConverter.txrefextDecode('tx1-r7ll-lrqq-qqqm-m5vjv');
+      expect(result.blockHeight).to.equal(blockHeight);
+      expect(result.blockIndex).to.equal(txPos);
+      expect(result.utxoIndex).to.equal(utxoIndex);
+      expect(result.chain).to.equal(txrefConverter.CHAIN_MAINNET);
+      done();
+    });
+
+    it('decodes txef-ext tx1-r7ll-llll-qqqn-sr5q8', function (done) {
+      let blockHeight = 0x1FFFFF;
+      let txPos = 0x1FFF;
+      let utxoIndex = 0;
+
+      let result =
+      txrefConverter.txrefextDecode('tx1-r7ll-llll-qqqn-sr5q8');
+      expect(result.blockHeight).to.equal(blockHeight);
+      expect(result.blockIndex).to.equal(txPos);
+      expect(result.utxoIndex).to.equal(utxoIndex);
+      expect(result.chain).to.equal(txrefConverter.CHAIN_MAINNET);
+      done();
+    });
+
+    it('decodes txef-ext tx1-r7ll-llll-yrq2-klazk', function (done) {
+      let blockHeight = 0x1FFFFF;
+      let txPos = 0x1FFF;
+      let utxoIndex = 100;
+
+      let result =
+      txrefConverter.txrefextDecode('tx1-r7ll-llll-yrq2-klazk');
+      expect(result.blockHeight).to.equal(blockHeight);
+      expect(result.blockIndex).to.equal(txPos);
+      expect(result.utxoIndex).to.equal(utxoIndex);
+      expect(result.chain).to.equal(txrefConverter.CHAIN_MAINNET);
+      done();
+    });
   });
 
   describe('end-to-end', function () {

--- a/tests.js
+++ b/tests.js
@@ -266,7 +266,7 @@ describe('Bech32 TX', function () {
       let blockHeight = 0;
       let txPos = 0;
       let utxoIndex = 0;
-      let result = txrefConverter.txrefextEncode(txrefConverter.CHAIN_MAINNET, blockHeight, txPos, utxoIndex);
+      let result = txrefConverter.txrefEncode(txrefConverter.CHAIN_MAINNET, blockHeight, txPos, utxoIndex);
       expect(result).to.equal('tx1-rqqq-qqqq-qqqu-au7hl');
       done();
     });
@@ -275,7 +275,7 @@ describe('Bech32 TX', function () {
       let blockHeight = 0;
       let txPos = 0;
       let utxoIndex = 100;
-      let result = txrefConverter.txrefextEncode(txrefConverter.CHAIN_MAINNET, blockHeight, txPos, utxoIndex);
+      let result = txrefConverter.txrefEncode(txrefConverter.CHAIN_MAINNET, blockHeight, txPos, utxoIndex);
       expect(result).to.equal('tx1-rqqq-qqqq-yrq9-mqh4w');
       done();
     });
@@ -284,7 +284,7 @@ describe('Bech32 TX', function () {
       let blockHeight = 0;
       let txPos = 0;
       let utxoIndex = 0x1FFF;
-      let result = txrefConverter.txrefextEncode(txrefConverter.CHAIN_MAINNET, blockHeight, txPos, utxoIndex);
+      let result = txrefConverter.txrefEncode(txrefConverter.CHAIN_MAINNET, blockHeight, txPos, utxoIndex);
       expect(result).to.equal('tx1-rqqq-qqqq-ll8t-emcac');
       done();
     });
@@ -293,7 +293,7 @@ describe('Bech32 TX', function () {
       let blockHeight = 0;
       let txPos = 0x1FFF;
       let utxoIndex = 0;
-      let result = txrefConverter.txrefextEncode(txrefConverter.CHAIN_MAINNET, blockHeight, txPos, utxoIndex);
+      let result = txrefConverter.txrefEncode(txrefConverter.CHAIN_MAINNET, blockHeight, txPos, utxoIndex);
       expect(result).to.equal('tx1-rqqq-qull-qqq5-ktx95');
       done();
     });
@@ -302,7 +302,7 @@ describe('Bech32 TX', function () {
       let blockHeight = 0;
       let txPos = 0x1FFF;
       let utxoIndex = 100;
-      let result = txrefConverter.txrefextEncode(txrefConverter.CHAIN_MAINNET, blockHeight, txPos, utxoIndex);
+      let result = txrefConverter.txrefEncode(txrefConverter.CHAIN_MAINNET, blockHeight, txPos, utxoIndex);
       expect(result).to.equal('tx1-rqqq-qull-yrqd-sh089');
       done();
     });
@@ -311,7 +311,7 @@ describe('Bech32 TX', function () {
       let blockHeight = 0x1FFFFF;
       let txPos = 0;
       let utxoIndex = 0;
-      let result = txrefConverter.txrefextEncode(txrefConverter.CHAIN_MAINNET, blockHeight, txPos, utxoIndex);
+      let result = txrefConverter.txrefEncode(txrefConverter.CHAIN_MAINNET, blockHeight, txPos, utxoIndex);
       expect(result).to.equal('tx1-r7ll-lrqq-qqqm-m5vjv');
       done();
     });
@@ -320,7 +320,7 @@ describe('Bech32 TX', function () {
       let blockHeight = 0x1FFFFF;
       let txPos = 0x1FFF;
       let utxoIndex = 0;
-      let result = txrefConverter.txrefextEncode(txrefConverter.CHAIN_MAINNET, blockHeight, txPos, utxoIndex);
+      let result = txrefConverter.txrefEncode(txrefConverter.CHAIN_MAINNET, blockHeight, txPos, utxoIndex);
       expect(result).to.equal('tx1-r7ll-llll-qqqn-sr5q8');
       done();
     });
@@ -329,7 +329,7 @@ describe('Bech32 TX', function () {
       let blockHeight = 0x1FFFFF;
       let txPos = 0x1FFF;
       let utxoIndex = 100;
-      let result = txrefConverter.txrefextEncode(txrefConverter.CHAIN_MAINNET, blockHeight, txPos, utxoIndex);
+      let result = txrefConverter.txrefEncode(txrefConverter.CHAIN_MAINNET, blockHeight, txPos, utxoIndex);
       expect(result).to.equal('tx1-r7ll-llll-yrq2-klazk');
       done();
     });
@@ -341,7 +341,7 @@ describe('Bech32 TX', function () {
       let txPos = 0;
       let utxoIndex = 0;
 
-      let result = txrefConverter.txrefextDecode('tx1-rqqq-qqqq-qqqu-au7hl');
+      let result = txrefConverter.txrefDecode('tx1-rqqq-qqqq-qqqu-au7hl');
       expect(result.blockHeight).to.equal(blockHeight);
       expect(result.blockIndex).to.equal(txPos);
       expect(result.utxoIndex).to.equal(utxoIndex);
@@ -354,7 +354,7 @@ describe('Bech32 TX', function () {
       let txPos = 0;
       let utxoIndex = 100;
 
-      let result = txrefConverter.txrefextDecode('tx1-rqqq-qqqq-yrq9-mqh4w');
+      let result = txrefConverter.txrefDecode('tx1-rqqq-qqqq-yrq9-mqh4w');
       expect(result.blockHeight).to.equal(blockHeight);
       expect(result.blockIndex).to.equal(txPos);
       expect(result.utxoIndex).to.equal(utxoIndex);
@@ -367,7 +367,7 @@ describe('Bech32 TX', function () {
       let txPos = 0;
       let utxoIndex = 0x1FFF;
 
-      let result = txrefConverter.txrefextDecode('tx1-rqqq-qqqq-ll8t-emcac');
+      let result = txrefConverter.txrefDecode('tx1-rqqq-qqqq-ll8t-emcac');
       expect(result.blockHeight).to.equal(blockHeight);
       expect(result.blockIndex).to.equal(txPos);
       expect(result.utxoIndex).to.equal(utxoIndex);
@@ -380,8 +380,7 @@ describe('Bech32 TX', function () {
       let txPos = 0x1FFF;
       let utxoIndex = 0;
 
-      let result =
-      txrefConverter.txrefextDecode('tx1-rqqq-qull-qqq5-ktx95');
+      let result = txrefConverter.txrefDecode('tx1-rqqq-qull-qqq5-ktx95');
       expect(result.blockHeight).to.equal(blockHeight);
       expect(result.blockIndex).to.equal(txPos);
       expect(result.utxoIndex).to.equal(utxoIndex);
@@ -394,8 +393,7 @@ describe('Bech32 TX', function () {
       let txPos = 0x1FFF;
       let utxoIndex = 100;
 
-      let result =
-      txrefConverter.txrefextDecode('tx1-rqqq-qull-yrqd-sh089');
+      let result = txrefConverter.txrefDecode('tx1-rqqq-qull-yrqd-sh089');
       expect(result.blockHeight).to.equal(blockHeight);
       expect(result.blockIndex).to.equal(txPos);
       expect(result.utxoIndex).to.equal(utxoIndex);
@@ -408,8 +406,7 @@ describe('Bech32 TX', function () {
       let txPos = 0;
       let utxoIndex = 0;
 
-      let result =
-      txrefConverter.txrefextDecode('tx1-r7ll-lrqq-qqqm-m5vjv');
+      let result = txrefConverter.txrefDecode('tx1-r7ll-lrqq-qqqm-m5vjv');
       expect(result.blockHeight).to.equal(blockHeight);
       expect(result.blockIndex).to.equal(txPos);
       expect(result.utxoIndex).to.equal(utxoIndex);
@@ -422,8 +419,7 @@ describe('Bech32 TX', function () {
       let txPos = 0x1FFF;
       let utxoIndex = 0;
 
-      let result =
-      txrefConverter.txrefextDecode('tx1-r7ll-llll-qqqn-sr5q8');
+      let result = txrefConverter.txrefDecode('tx1-r7ll-llll-qqqn-sr5q8');
       expect(result.blockHeight).to.equal(blockHeight);
       expect(result.blockIndex).to.equal(txPos);
       expect(result.utxoIndex).to.equal(utxoIndex);
@@ -436,8 +432,7 @@ describe('Bech32 TX', function () {
       let txPos = 0x1FFF;
       let utxoIndex = 100;
 
-      let result =
-      txrefConverter.txrefextDecode('tx1-r7ll-llll-yrq2-klazk');
+      let result = txrefConverter.txrefDecode('tx1-r7ll-llll-yrq2-klazk');
       expect(result.blockHeight).to.equal(blockHeight);
       expect(result.blockIndex).to.equal(txPos);
       expect(result.utxoIndex).to.equal(utxoIndex);

--- a/txrefConverter.js
+++ b/txrefConverter.js
@@ -21,8 +21,6 @@ var txrefEncode = function (chain, blockHeight, txPos) {
   shortId = nonStandard ? [0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00] :
     [0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00];
 
-  shortId[0] = magic;
-
   if (
     (nonStandard && (blockHeight > 0x1FFFFF || txPos > 0x1FFF || magic > 0x1F))
     ||
@@ -70,6 +68,68 @@ var txrefEncode = function (chain, blockHeight, txPos) {
   return finalResult;
 };
 
+var txrefextEncode = function (chain, blockHeight, txPos, utxoIndex) {
+  let magic = chain === CHAIN_MAINNET ? MAGIC_BTC_MAINNET : MAGIC_BTC_TESTNET;
+  let prefix = chain === CHAIN_MAINNET ? TXREF_BECH32_HRP_MAINNET : TXREF_BECH32_HRP_TESTNET;
+  let nonStandard = chain != CHAIN_MAINNET;
+
+  var shortId;
+  shortId = nonStandard ? 
+  [0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00] : // 13
+  [0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]; // 11
+
+  if (
+    (nonStandard && (blockHeight > 0x1FFFFF || txPos > 0x1FFF || utxoIndex > 0x1FFF || magic > 0x1F))
+    ||
+    (nonStandard && (blockHeight > 0x3FFFFFF || txPos > 0x3FFFF || utxoIndex > 0x1FFF || magic > 0x1F))
+  ) {
+    return null;
+  }
+
+  /* set the magic */
+  shortId[0] = magic;
+
+  /* make sure the version bit is 0 */
+  shortId[1] &= ~(1 << 0);
+
+  shortId[1] |= ((blockHeight & 0xF) << 1);
+  shortId[2] |= ((blockHeight & 0x1F0) >> 4);
+  shortId[3] |= ((blockHeight & 0x3E00) >> 9);
+  shortId[4] |= ((blockHeight & 0x7C000) >> 14);
+
+  if (nonStandard) {
+    // use extended blockheight (up to 0x3FFFFFF)
+    // use extended txpos (up to 0x3FFFF)
+    shortId[5] |= ((blockHeight & 0xF80000) >> 19);
+    shortId[6] |= ((blockHeight & 0x3000000) >> 24);
+
+    shortId[6] |= ((txPos & 0x7) << 2);
+    shortId[7] |= ((txPos & 0xF8) >> 3);
+    shortId[8] |= ((txPos & 0x1F00) >> 8);
+    shortId[9] |= ((txPos & 0x3E000) >> 13);
+    shortId[10] |= ((utxoIndex & 0x1F));
+    shortId[11] |= ((utxoIndex & 0x3E0) >> 5);
+    shortId[12] |= ((utxoIndex & 0x1C00) >> 10);
+  } else {
+    shortId[5] |= ((blockHeight & 0x180000) >> 19);
+    shortId[5] |= ((txPos & 0x7) << 2);
+    shortId[6] |= ((txPos & 0xF8) >> 3);
+    shortId[7] |= ((txPos & 0x1F00) >> 8);
+    shortId[8] |= ((utxoIndex & 0x1F));
+    shortId[9] |= ((utxoIndex & 0x3E0) >> 5);
+    shortId[10] |= ((utxoIndex & 0x1C00) >> 10);
+  }
+
+  let result = bech32.encode(prefix, shortId);
+
+  let breakIndex = prefix.length + 1;
+  let finalResult = result.substring(0, breakIndex) + "-" +
+    result.substring(breakIndex, breakIndex + 4) + "-" +
+    result.substring(breakIndex + 4, breakIndex + 8) + "-" +
+    result.substring(breakIndex + 8, breakIndex + 12) + "-" +
+    result.substring(breakIndex + 12, result.length);
+  return finalResult;
+};
 
 var txrefDecode = function (bech32Tx) {
   let stripped = bech32Tx.replace(/-/g, '');
@@ -112,6 +172,58 @@ var txrefDecode = function (bech32Tx) {
   return {
     "blockHeight": blockHeight,
     "blockIndex": blockIndex,
+    "chain": chain
+  };
+};
+
+var txrefextDecode = function (bech32Tx) {
+  let stripped = bech32Tx.replace(/-/g, '');
+
+  let result = bech32.decode(stripped);
+  if (result === null) {
+    return null;
+  }
+  let buf = result.data;
+
+  let chainMarker = buf[0];
+  let nonStandard = chainMarker != MAGIC_BTC_MAINNET;
+
+  var bStart = (buf[1] >> 1) |
+    (buf[2] << 4) |
+    (buf[3] << 9) |
+    (buf[4] << 14);
+
+  var blockHeight = 0;
+  var blockIndex = 0;
+  var utxoIndex = 0;
+
+  if (nonStandard) {
+    blockHeight = bStart | (buf[5] << 19);
+    blockHeight |= ((buf[6] & 0x03) << 24);
+
+    blockIndex = (buf[6] & 0x1C) >> 2;
+    blockIndex |= (buf[7] << 3);
+    blockIndex |= (buf[8] << 8);
+    blockIndex |= (buf[9] << 13);
+    utxoIndex = buf[10];
+    utxoIndex |= (buf[11] << 5);
+    utxoIndex |= (buf[12] << 10);
+  } else {
+    blockHeight = bStart | ((buf[5] & 0x03) << 19);
+    blockIndex = (buf[5] & 0x1C) >> 2;
+    blockIndex |= (buf[6] << 3);
+    blockIndex |= (buf[7] << 8);
+    utxoIndex = buf[8];
+    utxoIndex |= (buf[9] << 5);
+    utxoIndex |= (buf[10] << 10);
+  }
+
+  let chain = chainMarker === MAGIC_BTC_MAINNET ? CHAIN_MAINNET : CHAIN_TESTNET;
+
+  return {
+    "blockHeight": blockHeight,
+    "blockIndex": blockIndex,
+    "utxoIndex": utxoIndex,
     "chain": chain
   };
 };
@@ -254,6 +366,8 @@ var txDetailsFromTxref = function (txref) {
 module.exports = {
   txrefDecode: txrefDecode,
   txrefEncode: txrefEncode,
+  txrefextEncode: txrefextEncode,
+  txrefextDecode: txrefextDecode,
   txidToTxref: txidToTxref,
   txrefToTxid: txrefToTxid,
   getTxDetails: getTxDetails,


### PR DESCRIPTION
I updated the txrefEncode() and txrefDecode() functions to be able to deal with original size or extended size txrefs--based on whether or not a specific utxoIndex is passed in. I also added a bunch of tests.

I did NOT modify any of the other functions, like txidToTxref(), mainly because I'm not sure how that would affect any other projects that are using this code. I hope you can take a look and modify as needed.